### PR TITLE
More on python 3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__
+venv/
+venv2/
+
+*.pyc
+*~

--- a/zookeeper_dashboard/common.py
+++ b/zookeeper_dashboard/common.py
@@ -12,4 +12,4 @@ def get_zookeeper_servers_as_list():
     return get_zookeeper_servers().split(',')
 
 def get_zookeeper_server(id):
-    return get_zookeeper_servers_as_list()[id]
+    return get_zookeeper_servers_as_list()[int(id)]

--- a/zookeeper_dashboard/common.py
+++ b/zookeeper_dashboard/common.py
@@ -3,4 +3,13 @@ import os
 from django.conf import settings
 
 def get_zookeeper_servers():
-    return os.getenv('ZOOKEEPER_SERVERS') or getattr(settings,'ZOOKEEPER_SERVERS')
+    return (
+        os.getenv('ZOOKEEPER_SERVERS')
+        or getattr(settings,'ZOOKEEPER_SERVERS')
+    )
+
+def get_zookeeper_servers_as_list():
+    return get_zookeeper_servers().split(',')
+
+def get_zookeeper_server(id):
+    return get_zookeeper_servers_as_list()[id]

--- a/zookeeper_dashboard/zkadmin/views.py
+++ b/zookeeper_dashboard/zkadmin/views.py
@@ -1,23 +1,23 @@
 from django.shortcuts import render_to_response
 
 from zookeeper_dashboard.zkadmin.models import ZKServer
-from zookeeper_dashboard.common import get_zookeeper_servers
+from zookeeper_dashboard.common import get_zookeeper_servers_as_list, get_zookeeper_server
 
-ZOOKEEPER_SERVERS = get_zookeeper_servers().split(',')
 
 def index(request):
+    zookeeper_servers = get_zookeeper_servers_as_list()
     server_data = []
-    for i, server in enumerate(ZOOKEEPER_SERVERS):
+    for i, server in enumerate(zookeeper_servers):
         zkserver = ZKServer(server)
         zkserver.id = i
         server_data.append(zkserver)
 
     return render_to_response('zkadmin/index.html',
-                              {'ZOOKEEPER_SERVERS':ZOOKEEPER_SERVERS,
-                               'server_data':server_data})
+                              {'ZOOKEEPER_SERVERS': zookeeper_servers,
+                               'server_data': server_data})
 
 def detail(request, server_id):
-    server_data = ZKServer(ZOOKEEPER_SERVERS[int(server_id)])
+    server_data = ZKServer(get_zookeeper_server(server_id))
     server_data.id = server_id
     return render_to_response('zkadmin/detail.html',
                               {'server_data':server_data})

--- a/zookeeper_dashboard/zktree/models.py
+++ b/zookeeper_dashboard/zktree/models.py
@@ -31,7 +31,6 @@ class ZKClient(object):
     def get_acls(self, path):
         return self.zk_client.get_acls(path)
 
-ZOOKEEPER_SERVERS = get_zookeeper_servers()
 
 class ZNode(object):
     @staticmethod
@@ -65,7 +64,7 @@ class ZNode(object):
 
     def __init__(self, path="/"):
         self.path = path
-        zk = ZKClient(ZOOKEEPER_SERVERS, TIMEOUT)
+        zk = ZKClient(get_zookeeper_servers(), TIMEOUT)
         try:
             self.data, znode_stat = zk.get(path)
             self.stat = self.dict_from_znode_stat(znode_stat)

--- a/zookeeper_dashboard/zktree/views.py
+++ b/zookeeper_dashboard/zktree/views.py
@@ -1,6 +1,6 @@
 from django.shortcuts import render_to_response
 import string
-
+import traceback
 from zookeeper_dashboard.zktree.models import ZNode
 
 def istext(s, text_chars="".join(map(chr, range(32, 127))) + "\n\r\t\b"):
@@ -10,9 +10,6 @@ def istext(s, text_chars="".join(map(chr, range(32, 127))) + "\n\r\t\b"):
     return len(t) == 0
 
 def index(request, path=""):
-    import logging
-    logging.info("HEY")
-    print(path)
     path = "/" + path
     try:
         znode = ZNode(path)
@@ -26,5 +23,6 @@ def index(request, path=""):
         return render_to_response('zktree/index.html',
                                   {'znode':znode})
     except Exception as err:
+        traceback.print_exc()
         return render_to_response('zktree/error.html',
                                   {'error':str(err)})


### PR DESCRIPTION
Making errors visible and avoiding "catch pokémon" anti-pattern.
Making it to work in python 2 and 3 (now for sure).

I tried to catch `ConnectionRefusedError`, but it is just in python3. It seems both python 2 and 3 has socket.error and `ConnectionRefusedError` depends on it.
