### PR TITLE
Fix: Fix kazoo bug on windows platform when viewing znode tree

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 django==1.9
-kazoo==2.0
+kazoo==2.2.1
 gunicorn==19.0.0
 six==1.10.0


### PR DESCRIPTION
* issue: kazoo: error 10038 An operation was attempted on something that is not a socket
* please see  https://groups.google.com/d/msg/python-zk/EHdF-c_N0OI/6VTWuTHhdnUJ